### PR TITLE
Fix for bug 56: Update the link for online events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Join one of our weekly Community volunteer meetings:
 
 ## AI Alliance & Affiliated Groups
 * [By Region](https://github.com/The-AI-Alliance/community/blob/main/groups/regional.md)
-* [Online](https://github.com/The-AI-Alliance/community/blob/main/online/office-hours.md)
+* [Online](https://github.com/The-AI-Alliance/community/blob/main/events/office-hours/README.md)
 
 ## For More Information
 


### PR DESCRIPTION
Replaces the broken "online" link with the correct README.md link.